### PR TITLE
chore(vuln): zizmor --fix=all findings (SEC-199)

### DIFF
--- a/.github/workflows/rudderTransformation.yml
+++ b/.github/workflows/rudderTransformation.yml
@@ -15,7 +15,7 @@ jobs:
       TEST_ONLY: ${{ github.event_name != 'push' }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 


### PR DESCRIPTION
Remediate zizmor findings via `zizmor --fix=all` (SEC-199). Scope limited to `.github/`.